### PR TITLE
properly initialise arm setpoint

### DIFF
--- a/src/main/include/subsystems/ArmSubsystem.h
+++ b/src/main/include/subsystems/ArmSubsystem.h
@@ -61,7 +61,7 @@ class ArmSubsystem : public frc2::SubsystemBase {
 
   frc::TrapezoidProfile<units::turn> m_trapezoidalProfile{{ArmConstants::maximumVelocity, ArmConstants::maximumAcceleration}};
   frc::TrapezoidProfile<units::turn>::State m_armGoal;
-  frc::TrapezoidProfile<units::turn>::State m_armSetpoint;
+  frc::TrapezoidProfile<units::turn>::State m_armSetpoint{ArmConstants::resetEncoder, 0.0_tps};
   rev::spark::SparkClosedLoopController m_closedLoopController = m_armMotor.GetClosedLoopController();
 
   frc::ArmFeedforward m_armFeedforward{ArmConstants::kS, ArmConstants::kG, ArmConstants::kV, ArmConstants::kA};


### PR DESCRIPTION
By default, the arm setpoint state variable is initialised with zeros; however, our arm starts at a non-zero position. Apparently this messes up the first command sent out to the arm.

This change builds and works on the robot, and fixes the aforementioned issue.